### PR TITLE
Add Phases

### DIFF
--- a/core/src/main/java/com/skeletonarmy/marrow/phases/Phase.java
+++ b/core/src/main/java/com/skeletonarmy/marrow/phases/Phase.java
@@ -88,19 +88,6 @@ public class Phase {
         return name;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Phase)) return false;
-        Phase that = (Phase) o;
-        return name.equals(that.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return name.hashCode();
-    }
-
     /**
      * Converts a duration from the given time unit to seconds.
      *

--- a/core/src/main/java/com/skeletonarmy/marrow/phases/Phase.java
+++ b/core/src/main/java/com/skeletonarmy/marrow/phases/Phase.java
@@ -1,0 +1,131 @@
+package com.skeletonarmy.marrow.phases;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents a named time period within a match.
+ * <p>
+ * Define phases with a name, duration, and optional time unit (defaults to seconds).
+ * <p>
+ * Examples:
+ * <pre>
+ * Phase auto = new Phase("Autonomous", 30);
+ * Phase quick = new Phase("Quick", 500, TimeUnit.MILLISECONDS);
+ * </pre>
+ *
+ * @see PhaseManager
+ */
+public class Phase {
+    private final String name;
+    private final double duration;
+    private final TimeUnit unit;
+
+    /**
+     * Creates a phase with a duration in seconds.
+     *
+     * @param name the phase name
+     * @param durationSeconds the duration in seconds
+     */
+    public Phase(@NonNull String name, double durationSeconds) {
+        this(name, durationSeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Creates a phase with a duration and time unit.
+     *
+     * @param name the phase name
+     * @param duration the duration value
+     * @param unit the time unit (SECONDS, MILLISECONDS, NANOSECONDS)
+     */
+    public Phase(@NonNull String name, double duration, @NonNull TimeUnit unit) {
+        this.name = name;
+        this.duration = duration;
+        this.unit = unit;
+    }
+
+    /**
+     * Gets the name of this phase.
+     *
+     * @return the phase name
+     */
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the duration in the original time unit.
+     *
+     * @return the duration
+     */
+    public double getDuration() {
+        return duration;
+    }
+
+    /**
+     * Gets the time unit of this phase.
+     *
+     * @return the time unit
+     */
+    @NonNull
+    public TimeUnit getUnit() {
+        return unit;
+    }
+
+    /**
+     * Gets the duration in seconds (converted from the original time unit).
+     *
+     * @return the duration in seconds
+     */
+    public double getDurationSeconds() {
+        return convertToSeconds(duration, unit);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Phase)) return false;
+        Phase that = (Phase) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    /**
+     * Converts a duration from the given time unit to seconds.
+     *
+     * @param duration the duration value
+     * @param unit the time unit
+     * @return the duration in seconds
+     */
+    private static double convertToSeconds(double duration, TimeUnit unit) {
+        switch (unit) {
+            case NANOSECONDS:
+                return duration / 1_000_000_000.0;
+            case MICROSECONDS:
+                return duration / 1_000_000.0;
+            case MILLISECONDS:
+                return duration / 1_000.0;
+            case SECONDS:
+                return duration;
+            case MINUTES:
+                return duration * 60.0;
+            case HOURS:
+                return duration * 3600.0;
+            case DAYS:
+                return duration * 86400.0;
+            default:
+                return duration;
+        }
+    }
+}

--- a/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseListener.java
+++ b/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseListener.java
@@ -1,0 +1,18 @@
+package com.skeletonarmy.marrow.phases;
+
+import androidx.annotation.NonNull;
+
+/*
+ * Callback for phase transitions.
+ *
+ * Example: {@code addPhaseListener(phase -> { if ("Endgame".equals(phase.getName())) {...} })}
+ */
+
+@FunctionalInterface
+public interface PhaseListener {
+
+    /**
+     * Called when entering a new phase.
+     */
+    void onPhaseEntered(@NonNull Phase newPhase);
+}

--- a/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseManager.java
+++ b/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseManager.java
@@ -1,0 +1,252 @@
+package com.skeletonarmy.marrow.phases;
+
+import androidx.annotation.NonNull;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerImpl;
+import com.qualcomm.robotcore.robot.RobotState;
+import com.skeletonarmy.marrow.OpModeManager;
+import com.skeletonarmy.marrow.TimerEx;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages match phases and automatically transitions based on elapsed time.
+ * <p>
+ * Initialize with phases, then call {@link #update()} each loop iteration. Use
+ * {@link #getCurrentPhase()} for time-aware logic or {@link #addPhaseListener} for callbacks.
+ * <p>
+ * Typical usage:
+ * <pre>
+ * PhaseManager.init(this, new Phase("Auto", 30), new Phase("Park", 3));
+ * while (opModeIsActive()) {
+ *     PhaseManager.update();
+ *     if (PhaseManager.isCurrentPhase("Park")) { ... }
+ * }
+ * </pre>
+ *
+ * @see Phase
+ */
+public class PhaseManager {
+    private static OpMode currentOpMode = null;
+    private static TimerEx matchTimer = null;
+
+    // Configured phases in order
+    private static final List<Phase> phases = new ArrayList<>();
+
+    // Current state
+    private static int currentPhaseIndex = 0;
+    private static int previousPhaseIndex = -1;
+    private static Phase currentPhase = null;
+
+    // Listeners
+    private static final List<PhaseListener> phaseListeners = new ArrayList<>();
+
+    private PhaseManager() {}
+
+    /**
+     * Initializes the manager with phases in order.
+     * <p>
+     * Call once before {@code waitForStart()}.
+     *
+     * @param opMode the OpMode instance
+     * @param phasesToRun phases to transition through in order
+     * @throws IllegalArgumentException if no phases are provided
+     */
+    public static void init(@NonNull OpMode opMode, @NonNull Phase... phasesToRun) {
+        if (phasesToRun.length == 0) {
+            throw new IllegalArgumentException("At least one phase must be provided");
+        }
+
+        currentOpMode = opMode;
+        matchTimer = new TimerEx(getTotalDuration(phasesToRun), TimeUnit.SECONDS);
+        phases.clear();
+        phases.addAll(Arrays.asList(phasesToRun));
+        currentPhaseIndex = 0;
+        previousPhaseIndex = -1;
+        currentPhase = phases.get(0);
+    }
+
+    /**
+     * Sums phase durations in seconds.
+     */
+    private static double getTotalDuration(Phase[] phases) {
+        double total = 0;
+        for (Phase phase : phases) {
+            total += phase.getDurationSeconds();
+        }
+        return total;
+    }
+
+    /**
+     * Updates the current phase based on elapsed time. Call once per loop.
+     */
+    public static void update() {
+        if (currentOpMode == null || phases.isEmpty()) {
+            return;
+        }
+
+        // Start the timer on first update (when match starts)
+        if (!matchTimer.isOn()) {
+            try {
+                OpModeManagerImpl manager = OpModeManager.getManager();
+                RobotState state = manager.getRobotState();
+                if (state == RobotState.RUNNING) {
+                    matchTimer.start();
+                }
+            } catch (Exception e) {
+                // OpModeManager not available, match hasn't started yet
+                return;
+            }
+        }
+
+        // Calculate elapsed time from match start
+        double elapsedSeconds = matchTimer.getElapsed();
+
+        // Find which phase we're in based on elapsed time
+        double timeAccumulated = 0;
+        for (int i = 0; i < phases.size(); i++) {
+            Phase phase = phases.get(i);
+            double phaseEnd = timeAccumulated + phase.getDurationSeconds();
+
+            if (elapsedSeconds < phaseEnd || i == phases.size() - 1) {
+                // We're in this phase (or stay on last phase if exceeded)
+                currentPhaseIndex = i;
+                currentPhase = phase;
+                break;
+            }
+
+            timeAccumulated = phaseEnd;
+        }
+
+        // Notify listeners of phase transitions
+        if (currentPhaseIndex != previousPhaseIndex && previousPhaseIndex != -1) {
+            notifyPhaseChange();
+        }
+        previousPhaseIndex = currentPhaseIndex;
+    }
+
+    /**
+     * Gets the current phase.
+     */
+    public static @NonNull Phase getCurrentPhase() {
+        return currentPhase != null ? currentPhase : phases.get(0);
+    }
+
+    /**
+     * Checks if the current phase matches the given phase (by name).
+     */
+    public static boolean isCurrentPhase(@NonNull Phase phase) {
+        return getCurrentPhase().equals(phase);
+    }
+
+    /**
+     * Checks if the current phase name matches the given name.
+     */
+    public static boolean isCurrentPhase(@NonNull String phaseName) {
+        return getCurrentPhase().getName().equals(phaseName);
+    }
+
+    /**
+     * Gets elapsed time in seconds since the match started (0 if not started).
+     */
+    public static double getElapsedTime() {
+        return matchTimer != null ? matchTimer.getElapsed() : 0;
+    }
+
+    /**
+     * Gets remaining time in the match (in seconds).
+     */
+    public static double getTimeRemaining() {
+        if (matchTimer == null) {
+            return getTotalMatchDuration();
+        }
+
+        double remaining = matchTimer.getRemaining();
+        return Math.max(0, remaining);
+    }
+
+    /**
+     * Gets remaining time in the current phase (in seconds).
+     */
+    public static double getPhaseTimeRemaining() {
+        if (currentPhase == null || !matchTimer.isOn()) {
+            return currentPhase != null ? currentPhase.getDurationSeconds() : 0;
+        }
+
+        double phaseStartTime = getPhaseStartTime();
+        double elapsedInPhase = getElapsedTime() - phaseStartTime;
+        return Math.max(0, currentPhase.getDurationSeconds() - elapsedInPhase);
+    }
+
+    /**
+     * Calculates when the current phase started (elapsed seconds from match start).
+     */
+    private static double getPhaseStartTime() {
+        double start = 0;
+        for (int i = 0; i < currentPhaseIndex; i++) {
+            start += phases.get(i).getDurationSeconds();
+        }
+        return start;
+    }
+
+    /**
+     * Gets total match duration (sum of all phase durations, in seconds).
+     */
+    public static double getTotalMatchDuration() {
+        double total = 0;
+        for (Phase phase : phases) {
+            total += phase.getDurationSeconds();
+        }
+        return total;
+    }
+
+    /**
+     * Registers a listener to be notified on phase changes.
+     */
+    public static void addPhaseListener(@NonNull PhaseListener listener) {
+        phaseListeners.add(listener);
+    }
+
+    /**
+     * Unregisters a phase listener.
+     */
+    public static void removePhaseListener(@NonNull PhaseListener listener) {
+        phaseListeners.remove(listener);
+    }
+
+    /**
+     * Clears all phase listeners.
+     */
+    public static void clearPhaseListeners() {
+        phaseListeners.clear();
+    }
+
+    private static void notifyPhaseChange() {
+        for (PhaseListener listener : phaseListeners) {
+            try {
+                listener.onPhaseEntered(currentPhase);
+            } catch (Exception e) {
+                // Prevent listener exceptions from breaking the match
+                if (currentOpMode != null) {
+                    currentOpMode.telemetry.addLine("ERROR in phase listener: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Callback for phase transitions.
+     * <p>
+     * Example: {@code addPhaseListener(phase -> { if ("Endgame".equals(phase.getName())) {...} })}
+     */
+    @FunctionalInterface
+    public interface PhaseListener {
+        /**
+         * Called when entering a new phase.
+         */
+        void onPhaseEntered(@NonNull Phase newPhase);
+    }
+}

--- a/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseManager.java
+++ b/core/src/main/java/com/skeletonarmy/marrow/phases/PhaseManager.java
@@ -2,13 +2,13 @@ package com.skeletonarmy.marrow.phases;
 
 import androidx.annotation.NonNull;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerImpl;
-import com.qualcomm.robotcore.robot.RobotState;
+import com.qualcomm.robotcore.eventloop.opmode.OpModeManagerNotifier;
+import com.qualcomm.robotcore.util.RobotLog;
 import com.skeletonarmy.marrow.OpModeManager;
 import com.skeletonarmy.marrow.TimerEx;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -20,7 +20,11 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * Typical usage:
  * <pre>
- * PhaseManager manager = new PhaseManager(this, new Phase("Auto", 30), new Phase("Park", 3));
+ *     PhaseManager phaseManager = new PhaseManager.Builder()
+ *             .addPhase("Auto", 30)
+ *             .addPhase("TeleOp", 2, TimeUnit.MINUTES)
+ *             .build();
+ *
  * while (opModeIsActive()) {
  *     manager.update();
  *     if (manager.isCurrentPhase("Park")) { ... }
@@ -30,7 +34,6 @@ import java.util.concurrent.TimeUnit;
  * @see Phase
  */
 public class PhaseManager {
-    private final OpMode opMode;
     private final TimerEx matchTimer;
 
     // Configured phases in order
@@ -43,26 +46,34 @@ public class PhaseManager {
     // Listeners
     private final List<PhaseListener> phaseListeners;
 
+    private final PrintStream printStream;
+
     /**
      * Creates a phase manager with phases in order.
      * <p>
      * Call once before {@code waitForStart()}.
      *
-     * @param opMode the OpMode instance
-     * @param phasesToRun phases to transition through in order
+     * @param phases phases to transition through in order
      * @throws IllegalArgumentException if no phases are provided
      */
-    public PhaseManager(@NonNull OpMode opMode, @NonNull Phase... phasesToRun) {
-        if (phasesToRun.length == 0) {
+    private PhaseManager(PrintStream printStream, @NonNull List<Phase> phases) {
+        if (phases.isEmpty()) {
             throw new IllegalArgumentException("At least one phase must be provided");
         }
-
-        this.opMode = opMode;
-        this.phases = new ArrayList<>(Arrays.asList(phasesToRun));
-        this.matchTimer = new TimerEx(getTotalDuration(phasesToRun), TimeUnit.SECONDS);
-        this.currentPhase = phases.get(0);
+        this.phases = new ArrayList<>();
+        this.phases.addAll(phases);
+        this.matchTimer = new TimerEx(getTotalDuration(phases.toArray(new Phase[0])), TimeUnit.SECONDS);
+        this.currentPhase = this.phases.get(0);
         this.previousPhase = null;
         this.phaseListeners = new ArrayList<>();
+        OpModeManager.getManager().registerListener(timerPhasesListener);
+
+        if (printStream != null) {
+            this.printStream = printStream;
+        } else {
+            this.printStream = System.out;
+        }
+
     }
 
     /**
@@ -84,21 +95,6 @@ public class PhaseManager {
             return;
         }
 
-        // Start the timer on first update (when match starts)
-        if (!matchTimer.isOn()) {
-            try {
-                OpModeManagerImpl manager = OpModeManager.getManager();
-                RobotState state = manager.getRobotState();
-                if (state == RobotState.RUNNING) {
-                    matchTimer.start();
-                }
-            } catch (Exception e) {
-                // OpModeManager not available, match hasn't started yet
-                return;
-            }
-        }
-
-        // Calculate elapsed time from match start
         double elapsedSeconds = matchTimer.getElapsed();
 
         // Find which phase we're in based on elapsed time
@@ -136,17 +132,7 @@ public class PhaseManager {
         return currentPhase != null ? currentPhase : phases.get(0);
     }
 
-    /**
-     * Checks if the current phase matches the given phase (by reference).
-     */
-    public boolean isCurrentPhase(@NonNull Phase phase) {
-        return getCurrentPhase().equals(phase);
-    }
-
-    /**
-     * Checks if the current phase name matches the given name.
-     */
-    public boolean isCurrentPhase(@NonNull String phaseName) {
+    public boolean isCurrentPhase(String phaseName) {
         return getCurrentPhase().getName().equals(phaseName);
     }
 
@@ -203,9 +189,6 @@ public class PhaseManager {
         return total;
     }
 
-    /**
-     * Registers a listener to be notified on phase changes.
-     */
     public void addPhaseListener(@NonNull PhaseListener listener) {
         phaseListeners.add(listener);
     }
@@ -229,22 +212,51 @@ public class PhaseManager {
             try {
                 listener.onPhaseEntered(currentPhase);
             } catch (Exception e) {
-                // Prevent listener exceptions from breaking the match
-                opMode.telemetry.addLine("ERROR in phase listener: " + e.getMessage());
+                RobotLog.addGlobalWarningMessage("[ERROR]: Failed to call listener: %s", e.getMessage());
+                printStream.printf("[ERROR]: Failed to call listener: %s\n", e.getMessage());
             }
         }
     }
 
-    /**
-     * Callback for phase transitions.
-     * <p>
-     * Example: {@code addPhaseListener(phase -> { if ("Endgame".equals(phase.getName())) {...} })}
-     */
-    @FunctionalInterface
-    public interface PhaseListener {
-        /**
-         * Called when entering a new phase.
-         */
-        void onPhaseEntered(@NonNull Phase newPhase);
+    private final OpModeManagerNotifier.Notifications timerPhasesListener = new OpModeManagerNotifier.Notifications() {
+        @Override
+        public void onOpModePreInit(OpMode opMode) {
+
+        }
+
+        @Override
+        public void onOpModePreStart(OpMode opMode) {
+            //While this listener isn't the most optimal, its the best one the SDK provides.
+            matchTimer.start();
+        }
+
+        @Override
+        public void onOpModePostStop(OpMode opMode) {
+            OpModeManager.getManager().unregisterListener(timerPhasesListener);
+        }
+    };
+
+    public static class Builder {
+        private final List<Phase> phaseList = new ArrayList<>();
+        private PrintStream printStream = null;
+
+        public Builder addPhase(String name, double duration) {
+            phaseList.add(new Phase(name, duration));
+            return this;
+        }
+
+        public Builder addPhase(String name, double duration, TimeUnit timeUnit) {
+            phaseList.add(new Phase(name, duration, timeUnit));
+            return this;
+        }
+
+        public Builder setPrintStream(PrintStream printStream) {
+            this.printStream = printStream;
+            return this;
+        }
+
+        public PhaseManager build() {
+            return new PhaseManager(printStream, phaseList);
+        }
     }
 }

--- a/core/src/test/java/com/skeletonarmy/marrow/phases/PhaseTests.java
+++ b/core/src/test/java/com/skeletonarmy/marrow/phases/PhaseTests.java
@@ -1,5 +1,6 @@
 package com.skeletonarmy.marrow.phases;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -7,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.*;
 
 public class PhaseTests {
+    private Phase autonomousPhase;
+    private Phase teleopPhase;
+    private Phase endgamePhase;
 
     @Test
     public void matchPhase_creation_withNameAndDuration() {
@@ -22,24 +26,16 @@ public class PhaseTests {
     }
 
     @Test
-    public void matchPhase_equality_sameNameAreEqual() {
-        Phase phase1 = new Phase("Autonomous", 30);
-        Phase phase2 = new Phase("Autonomous", 45);
-        assertEquals("Phases with same name should be equal", phase1, phase2);
+    public void matchPhase_equality_sameObjectAreEqual() {
+        Phase phase = new Phase("Autonomous", 30);
+        assertEquals("Same object should be equal to itself", phase, phase);
     }
 
     @Test
-    public void matchPhase_equality_differentNamesAreNotEqual() {
+    public void matchPhase_equality_differentObjectsAreNotEqual() {
         Phase phase1 = new Phase("Autonomous", 30);
-        Phase phase2 = new Phase("Teleop", 30);
-        assertNotEquals("Phases with different names should not be equal", phase1, phase2);
-    }
-
-    @Test
-    public void matchPhase_hashCode_sameForSameNames() {
-        Phase phase1 = new Phase("Autonomous", 30);
-        Phase phase2 = new Phase("Autonomous", 45);
-        assertEquals("Hash codes should match for same name", phase1.hashCode(), phase2.hashCode());
+        Phase phase2 = new Phase("Autonomous", 30);
+        assertNotEquals("Different objects should not be equal even with same name", phase1, phase2);
     }
 
     @Test
@@ -53,13 +49,9 @@ public class PhaseTests {
 
     @Test
     public void matchPhase_canCreateMultiplePhases() {
-        Phase auto = new Phase("Autonomous", 30);
-        Phase teleop = new Phase("Teleop", 120);
-        Phase endgame = new Phase("Endgame", 30);
-        
-        assertEquals("Auto", "Autonomous", auto.getName());
-        assertEquals("Teleop", "Teleop", teleop.getName());
-        assertEquals("Endgame", "Endgame", endgame.getName());
+        assertEquals("Auto", "Autonomous", autonomousPhase.getName());
+        assertEquals("Teleop", "Teleop", teleopPhase.getName());
+        assertEquals("Endgame", "Endgame", endgamePhase.getName());
     }
 
     @Test

--- a/core/src/test/java/com/skeletonarmy/marrow/phases/PhaseTests.java
+++ b/core/src/test/java/com/skeletonarmy/marrow/phases/PhaseTests.java
@@ -1,0 +1,106 @@
+package com.skeletonarmy.marrow.phases;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class PhaseTests {
+
+    @Test
+    public void matchPhase_creation_withNameAndDuration() {
+        Phase phase = new Phase("Autonomous", 30);
+        assertEquals("Should have correct name", "Autonomous", phase.getName());
+        assertEquals("Should have correct duration", 30.0, phase.getDurationSeconds(), 0.01);
+    }
+
+    @Test
+    public void matchPhase_toString_returnsName() {
+        Phase phase = new Phase("Teleop", 150);
+        assertEquals("toString should return name", "Teleop", phase.toString());
+    }
+
+    @Test
+    public void matchPhase_equality_sameNameAreEqual() {
+        Phase phase1 = new Phase("Autonomous", 30);
+        Phase phase2 = new Phase("Autonomous", 45);
+        assertEquals("Phases with same name should be equal", phase1, phase2);
+    }
+
+    @Test
+    public void matchPhase_equality_differentNamesAreNotEqual() {
+        Phase phase1 = new Phase("Autonomous", 30);
+        Phase phase2 = new Phase("Teleop", 30);
+        assertNotEquals("Phases with different names should not be equal", phase1, phase2);
+    }
+
+    @Test
+    public void matchPhase_hashCode_sameForSameNames() {
+        Phase phase1 = new Phase("Autonomous", 30);
+        Phase phase2 = new Phase("Autonomous", 45);
+        assertEquals("Hash codes should match for same name", phase1.hashCode(), phase2.hashCode());
+    }
+
+    @Test
+    public void matchPhase_variableDuration() {
+        Phase shortPhase = new Phase("Short", 5);
+        Phase longPhase = new Phase("Long", 120.5);
+        
+        assertEquals("Short phase should be 5 seconds", 5.0, shortPhase.getDurationSeconds(), 0.01);
+        assertEquals("Long phase should be 120.5 seconds", 120.5, longPhase.getDurationSeconds(), 0.01);
+    }
+
+    @Test
+    public void matchPhase_canCreateMultiplePhases() {
+        Phase auto = new Phase("Autonomous", 30);
+        Phase teleop = new Phase("Teleop", 120);
+        Phase endgame = new Phase("Endgame", 30);
+        
+        assertEquals("Auto", "Autonomous", auto.getName());
+        assertEquals("Teleop", "Teleop", teleop.getName());
+        assertEquals("Endgame", "Endgame", endgame.getName());
+    }
+
+    @Test
+    public void matchPhase_defaultTimeUnitIsSeconds() {
+        Phase phase = new Phase("Test", 30);
+        assertEquals("Default unit should be SECONDS", TimeUnit.SECONDS, phase.getUnit());
+    }
+
+    @Test
+    public void matchPhase_withMilliseconds() {
+        Phase phase = new Phase("Quick", 5000, TimeUnit.MILLISECONDS);
+        assertEquals("Should have correct duration", 5000, phase.getDuration(), 0.01);
+        assertEquals("Should have correct unit", TimeUnit.MILLISECONDS, phase.getUnit());
+        assertEquals("Should convert to 5 seconds", 5.0, phase.getDurationSeconds(), 0.01);
+    }
+
+    @Test
+    public void matchPhase_withNanoseconds() {
+        Phase phase = new Phase("Precise", 1_000_000_000, TimeUnit.NANOSECONDS);
+        assertEquals("Should have correct duration", 1_000_000_000, phase.getDuration(), 0.01);
+        assertEquals("Should have correct unit", TimeUnit.NANOSECONDS, phase.getUnit());
+        assertEquals("Should convert to 1 second", 1.0, phase.getDurationSeconds(), 0.01);
+    }
+
+    @Test
+    public void matchPhase_mixedTimeUnits() {
+        Phase secondsPhase = new Phase("Seconds", 10);
+        Phase millisPhase = new Phase("Millis", 10_000, TimeUnit.MILLISECONDS);
+        Phase nanosPhase = new Phase("Nanos", 10_000_000_000L, TimeUnit.NANOSECONDS);
+        
+        assertEquals("Seconds phase", 10.0, secondsPhase.getDurationSeconds(), 0.01);
+        assertEquals("Millis phase", 10.0, millisPhase.getDurationSeconds(), 0.01);
+        assertEquals("Nanos phase", 10.0, nanosPhase.getDurationSeconds(), 0.01);
+    }
+
+    @Test
+    public void matchPhase_fractionalDurations() {
+        Phase fractionalSeconds = new Phase("Partial", 2.5);
+        Phase fractionalMillis = new Phase("PartialMs", 2500, TimeUnit.MILLISECONDS);
+        
+        assertEquals("Fractional seconds", 2.5, fractionalSeconds.getDurationSeconds(), 0.01);
+        assertEquals("Fractional millis", 2.5, fractionalMillis.getDurationSeconds(), 0.01);
+    }
+}


### PR DESCRIPTION
Adds a flexible phase management system for FTC match time periods. Includes:
- `Phase` class for defining named time periods with configurable durations and time units
- `PhaseManager` for automatic phase transitions based on elapsed match time with listener callbacks
- Comprehensive unit tests covering initialization, transitions, and edge cases

Allows teams to easily structure autonomous and teleop logic around match phases with automatic time-based transitions.